### PR TITLE
add public unwrap function to ModalPathDestination

### DIFF
--- a/Sources/Navigate/ModalStack/ModalPathDestination.swift
+++ b/Sources/Navigate/ModalStack/ModalPathDestination.swift
@@ -19,6 +19,10 @@ public struct ModalPathDestination: NavigationDestination {
 	func unwrap<D: NavigationDestination>() -> D {
 		destination as! D
 	}
+    
+    public func unwrap<D: NavigationDestination>(_ type: D.Type) -> D? {
+        destination as? D
+    }
 	
 	public var id: AnyHashable {
 		destination.id as! AnyHashable


### PR DESCRIPTION
This enables more advanced router implementations that need to know which destinations are already in the path.